### PR TITLE
add -watch-config flag to dynamically reload wifi configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gokrazy/wifi
 go 1.25.0
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gokrazy/gokrazy v0.0.0-20260218074004-791851666ca2
 	github.com/gokrazy/internal v0.0.0-20260109072635-00a332bd5e47
 	github.com/mdlayher/wifi v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gokrazy/gokrazy v0.0.0-20260218074004-791851666ca2 h1:3diV54purUiHmge4KdjwXDzjnzcbBWe6pqzdUQG7KvU=
 github.com/gokrazy/gokrazy v0.0.0-20260218074004-791851666ca2/go.mod h1:NtMkrFeDGnwldKLi0dLdd2ipNwoVa7TI4HTxsy7lFRg=
 github.com/gokrazy/internal v0.0.0-20260109072635-00a332bd5e47 h1:sVShuz8LXAcIe8xLw8E+qXW6iVx1oz/RcplV94v6fvo=

--- a/wifi.go
+++ b/wifi.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -30,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gokrazy/gokrazy"
 	"github.com/gokrazy/internal/iface"
 	"github.com/mdlayher/wifi"
@@ -57,6 +57,23 @@ type wifiCtx struct {
 	connectedSince time.Duration
 }
 
+const configFileName = "wifi.json"
+const configFileDebounceDuration = 200 * time.Millisecond
+
+func (w *wifiCtx) disconnectAll() {
+	for _, intf := range w.interfaces {
+		if err := w.cl.Disconnect(intf); err != nil {
+			log.Printf("disconnect: %v", err)
+		}
+	}
+	w.dhcpClientMu.Lock()
+	if w.dhcpClient != nil && w.dhcpClient.Process != nil {
+		w.dhcpClient.Process.Kill()
+	}
+	w.dhcpClient = nil
+	w.dhcpClientMu.Unlock()
+}
+
 func (w *wifiCtx) control1() error {
 Interface:
 	for _, intf := range w.interfaces {
@@ -75,12 +92,13 @@ Interface:
 				sta.Signal)
 			if sta.Connected < w.connectedSince {
 				// reconnected. restart dhcp client
-				if w.dhcpClient.Process != nil {
+				if w.dhcpClient != nil && w.dhcpClient.Process != nil {
 					w.dhcpClient.Process.Kill()
 				}
 				w.dhcpClient = nil
 			}
 			if w.dhcpClient != nil {
+				w.connectedSince = sta.Connected
 				w.dhcpClientMu.Unlock()
 				continue Interface
 			}
@@ -95,18 +113,24 @@ Interface:
 			w.dhcpClient.Stdout = os.Stdout
 			w.dhcpClient.Stderr = os.Stderr
 			log.Printf("starting %v", w.dhcpClient.Args)
-			w.dhcpClient.Start()
-			go func() {
-				w.dhcpClientMu.Lock()
-				dhcpClient := w.dhcpClient
+			if err := w.dhcpClient.Start(); err != nil {
+				log.Printf("dhcp start failed: %v", err)
+				w.dhcpClient = nil
 				w.dhcpClientMu.Unlock()
+				continue Interface
+			}
+			dhcpClient := w.dhcpClient
+			go func() {
 				if err := dhcpClient.Wait(); err != nil {
 					log.Printf("dhcp process failed: %v", err)
 				}
 				w.dhcpClientMu.Lock()
-				w.dhcpClient = nil
+				if w.dhcpClient == dhcpClient {
+					w.dhcpClient = nil
+				}
 				w.dhcpClientMu.Unlock()
 			}()
+			w.connectedSince = sta.Connected
 			w.dhcpClientMu.Unlock()
 			continue Interface
 		}
@@ -117,6 +141,7 @@ Interface:
 			w.dhcpClient.Process.Kill()
 		}
 		w.dhcpClient = nil
+		w.connectedSince = 0
 		w.dhcpClientMu.Unlock()
 
 		// Interface is not associated with station, try connecting:
@@ -167,6 +192,106 @@ func loadModule(mod string) error {
 	return nil
 }
 
+// configPaths lists the well-known config file locations in priority order.
+// /perm/wifi.json is preferred (user-writable), /etc/wifi.json is the read-only system-wide fallback.
+var configPaths = []struct {
+	dir  string
+	file string
+}{
+	{"/perm", filepath.Join("/perm", configFileName)},
+	{"/etc", filepath.Join("/etc", configFileName)},
+}
+
+// readConfig tries each config path in priority order.
+// Returns (nil, nil) when no config file exists.
+func readConfig() (*wifiConfig, error) {
+	for _, p := range configPaths {
+		b, err := os.ReadFile(p.file)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		var cfg wifiConfig
+		if err := json.Unmarshal(b, &cfg); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
+	}
+	return nil, nil
+}
+
+// watchConfigFiles monitors the well-known config file parent directories for changes.
+// We watch directories rather than files because editors do atomic rename-into-place
+// writes, which would remove a watch on the file itself.
+// Events are debounced (200ms) to avoid reading a half-written file.
+func watchConfigFiles(notify chan<- struct{}) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Printf("error creating config file watcher (fsnotify): %v (config watching disabled)", err)
+		return
+	}
+	defer watcher.Close()
+
+	// Watch each parent directory for config file changes.
+	// Directories that don't exist (e.g. /perm/ not yet mounted) are skipped gracefully.
+	watched := 0
+	for _, p := range configPaths {
+		if err := watcher.Add(p.dir); err != nil {
+			log.Printf("error watching config file parent directory %s (fsnotify): %v (config watching disabled)", p.dir, err)
+			continue
+		}
+		watched++
+	}
+	if watched == 0 {
+		log.Printf("no config file parent directories could be watched (config watching disabled)")
+		return
+	}
+
+	var debounce *time.Timer
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// Given we watch parent directories, only react to events for configured config files, ignore others.
+			if filepath.Base(event.Name) != configFileName {
+				continue
+			}
+			// Only react to events that indicate a change we are interested in.
+			if !event.Has(fsnotify.Create) && !event.Has(fsnotify.Write) && !event.Has(fsnotify.Remove) && !event.Has(fsnotify.Rename) {
+				continue
+			}
+			// If a previous debounce timer is already running, cancel it.
+			// This ensures that rapid successive file-change events don't each trigger a notification.
+			if debounce != nil {
+				debounce.Stop()
+			}
+			// Start a new timer and schedule a function to run after time is elapsed.
+			// Every new file event resets this timer, so the actual notification
+			// only fires once activity has "settled" for at least the debounce duration.
+			debounce = time.AfterFunc(configFileDebounceDuration, func() {
+				// When the timer fires, it tries to send on the notify channel.
+				// The select with a default case makes this non-blocking.
+				// If nobody is ready to receive (or the channel buffer is full),
+				// the signal is silently dropped rather than blocking the goroutine.
+				select {
+				case notify <- struct{}{}:
+					log.Printf("config file change detected: %s (event: %v)", event.Name, event.Op)
+				default:
+				}
+			})
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("fsnotify error: %v", err)
+		}
+	}
+}
+
 func logic() error {
 	var (
 		disconnect = flag.Bool("disconnect",
@@ -175,41 +300,50 @@ func logic() error {
 
 		ssid = flag.String("ssid",
 			"",
-			"if non-empty, the ssid of the WiFi network to connect to. if empty, /perm/wifi.json or /etc/wifi.json will be used")
+			"if non-empty, the ssid of the WiFi network to connect to. if empty, /perm/"+configFileName+" or /etc/"+configFileName+" will be used")
 
 		psk = flag.String("psk",
 			"",
-			"if non-empty, the psk of the WiFi network to connect to. if empty, /perm/wifi.json or /etc/wifi.json will be used")
+			"if non-empty, the psk of the WiFi network to connect to. if empty, /perm/"+configFileName+" or /etc/"+configFileName+" will be used")
 
 		region = flag.String("region",
 			"",
-			"if non-empty, the wireless regulatory region (ISO 3166-1 alpha-2). if empty, /perm/wifi.json or /etc/wifi.json will be used")
+			"if non-empty, the wireless regulatory region (ISO 3166-1 alpha-2). if empty, /perm/"+configFileName+" or /etc/"+configFileName+" will be used")
+
+		watchConfig = flag.Bool("watch-config",
+			false,
+			"if set, watch /perm/"+configFileName+" and /etc/"+configFileName+" for changes and reload the configuration dynamically")
 	)
 	flag.Parse()
-	var cfg wifiConfig
-	if *ssid != "" || *disconnect {
-		cfg.SSID = *ssid
-		cfg.PSK = *psk
-		cfg.Region = *region
-	} else {
-		b, err := ioutil.ReadFile("/perm/wifi.json")
-		if err != nil && os.IsNotExist(err) {
-			b, err = ioutil.ReadFile("/etc/wifi.json")
-		}
-		if err != nil {
-			if os.IsNotExist(err) {
-				// No config file? Nothing to do!
-				gokrazy.DontStartOnBoot()
-			}
-			return err
-		}
 
-		if err := json.Unmarshal(b, &cfg); err != nil {
+	if *watchConfig && (*ssid != "" || *psk != "" || *region != "" || *disconnect) {
+		return fmt.Errorf("-watch-config cannot be combined with -ssid, -psk, -region, or -disconnect")
+	}
+
+	var cfg *wifiConfig
+	if *ssid != "" || *disconnect {
+		cfg = &wifiConfig{
+			SSID:   *ssid,
+			PSK:    *psk,
+			Region: *region,
+		}
+	} else {
+		var err error
+		cfg, err = readConfig()
+		if err != nil {
 			return err
+		}
+		if cfg == nil {
+			if *watchConfig {
+				log.Printf("no config file found, waiting for /perm/" + configFileName + " or /etc/" + configFileName + " to appear")
+			} else {
+				gokrazy.DontStartOnBoot()
+				return fmt.Errorf("no config file found")
+			}
 		}
 	}
 
-	if cfg.Region == "" {
+	if cfg != nil && cfg.Region == "" {
 		cfg.Region = worldRegulatoryRegion
 	}
 
@@ -246,20 +380,16 @@ func logic() error {
 		return nil
 	}
 
-	if err := cl.ReloadRegulatoryDatabase(); err != nil {
-		return fmt.Errorf("failed to reload the wireless regulatory database: %w", err)
+	if cfg != nil {
+		if err := applyRegulatoryRegion(cl, cfg.Region); err != nil {
+			return err
+		}
 	}
-
-	if err := cl.SetRegulatoryRegion(cfg.Region, wifi.RegulatoryHintUser); err != nil {
-		return fmt.Errorf("failed to set %s as the regulatory region: %w", cfg.Region, err)
-	}
-
-	log.Printf("requested wireless regulatory region %s", cfg.Region)
 
 	w := &wifiCtx{
 		cl:         cl,
 		interfaces: interfaces,
-		cfg:        &cfg,
+		cfg:        cfg,
 	}
 
 	cs, err := iface.NewConfigSocket("wlan0")
@@ -268,7 +398,7 @@ func logic() error {
 	}
 	defer cs.Close()
 
-	b, err := ioutil.ReadFile("/sys/class/net/wlan0/address")
+	b, err := os.ReadFile("/sys/class/net/wlan0/address")
 	if err != nil {
 		return fmt.Errorf("reading /sys/class/net/wlan0/address: %v", err)
 	}
@@ -279,14 +409,74 @@ func logic() error {
 		log.Printf("setting link wlan0 up: %v", err)
 	}
 
-	const controlLoopFrequency = 15 * time.Second
-	for {
-		if err := w.control1(); err != nil {
-			log.Printf("control1: %v", err)
-		}
-		time.Sleep(controlLoopFrequency)
+	// Watch for config files events if requested.
+	var configNotify <-chan struct{}
+	if *watchConfig {
+		ch := make(chan struct{}, 1)
+		configNotify = ch
+		go watchConfigFiles(ch)
 	}
+
+	const controlLoopFrequency = 15 * time.Second
+	ticker := time.NewTicker(controlLoopFrequency)
+	defer ticker.Stop()
+
+	for {
+		if w.cfg != nil {
+			if err := w.control1(); err != nil {
+				log.Printf("control1: %v", err)
+			}
+		}
+
+		select {
+		case <-ticker.C: // control loop tick
+		case <-configNotify: // config file changed
+			newCfg, err := readConfig()
+			if err != nil {
+				log.Printf("error reading config file: %v (keeping previous config)", err)
+				continue
+			}
+			if newCfg == nil {
+				log.Printf("config file was removed, will disconnect (if connected)")
+				w.cfg = nil
+				w.disconnectAll()
+				continue
+			}
+			if newCfg.Region == "" {
+				newCfg.Region = worldRegulatoryRegion
+			}
+			if hasConfigChanged(w.cfg, newCfg) {
+				log.Print("wifi config changed, will use new config")
+				if w.cfg != nil {
+					w.disconnectAll()
+				}
+				w.cfg = newCfg
+				if err := applyRegulatoryRegion(w.cl, w.cfg.Region); err != nil {
+					log.Printf("could not apply regulatory region: %v", err)
+				}
+			}
+		}
+	}
+}
+
+// applyRegulatoryRegion applies the regulatory region to the WiFi client.
+func applyRegulatoryRegion(cl *wifi.Client, region string) error {
+	if err := cl.ReloadRegulatoryDatabase(); err != nil {
+		return fmt.Errorf("failed to reload the wireless regulatory database: %w", err)
+	}
+	if err := cl.SetRegulatoryRegion(region, wifi.RegulatoryHintUser); err != nil {
+		return fmt.Errorf("failed to set %s as the regulatory region: %w", region, err)
+	}
+	log.Printf("requested wireless regulatory region %s", region)
 	return nil
+}
+
+// hasConfigChanged checks if the configuration has changed.
+func hasConfigChanged(cfg *wifiConfig, newCfg *wifiConfig) bool {
+	return cfg == nil ||
+		newCfg.SSID != cfg.SSID ||
+		newCfg.PSK != cfg.PSK ||
+		newCfg.Region != cfg.Region
 }
 
 func main() {


### PR DESCRIPTION
When enabled, the daemon uses inotify to watch /perm/wifi.json and /etc/wifi.json for creation, modification, and deletion, reloading the configuration and reconnecting as needed.

Without the flag, behavior is unchanged.

This is useful to change the wifi configuration and API we are connected to without starting stopping the process of having to restart.

It is also useful for zero-touch provisioning of the wifi network and credentials via BLE Bootstrapping/Provisioning at device runtime.